### PR TITLE
Issue 25: Modify licensing notices

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -5,7 +5,9 @@ The instructional material in this course is copyright © 2023 University of Exe
 and is made available under the Creative Commons Attribution 4.0 International
 licence (https://creativecommons.org/licenses/by/4.0/). Instructional material
 consists of material that is contained within the _episodes and images folders in
-this repository.
+this repository, with the exception of code snippets and example programs found
+in files within these folders. Such code snippets and example programs are
+considered software for the purposes of this licence. 
 
 
 Software

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -33,12 +33,22 @@
     <div id="footer_wrap" class="outer">
       <footer class="inner">
         {% include prev_next_navbar.html %}
+        <p class="copyright">The material on this page is © University of Exeter.</p>
         {% if page.adapted %}
-        <p class="copyright">The material on this page is © University of Exeter and licensed under <a href ="https://creativecommons.org/licenses/by/4.0/">Creative Commons BY 4.0.</a> 
-          It has been adapted from <a href="{{ page.attrib_link }}">{{ page.attrib_name }}</a> which is © {{ page.attrib_copywrite }} and licensed under <a href ={{ page.attrib_license_link }}>{{ page.attrib_license }}</a></p>
+        <p class="copyright">Material other than code snippets and example
+          programs is licensed under <a href ="https://creativecommons.org/licenses/by/4.0/">Creative Commons BY 4.0</a>. 
+          It has been adapted from <a href="{{ page.attrib_link }}">{{ page.attrib_name }}</a>
+          which is © {{ page.attrib_copywrite }} and licensed under <a href ={{ page.attrib_license_link }}>{{ page.attrib_license }}</a>.
+        </p>
         {% else %}
-        <p class="copyright">The material on this page is © University of Exeter and licensed under <a href ="https://creativecommons.org/licenses/by/4.0/">Creative Commons BY 4.0.</a></p>
-        {% endif %}        
+        <p class="copyright">Material other than code snippets and example
+          programs is licensed under <a href ="https://creativecommons.org/licenses/by/4.0/">Creative Commons BY 4.0</a>.
+        </p>
+        {% endif %} 
+        <p class="copyright">The code snippets and example programs on this page
+          are MIT licensed, according to the licence notice found in this website's
+          <a href="https://github.com/UniExeterRSE/intro-version-control" target="_blank" rel="external noreferrer">code repository</a>.
+        </p>
         {% if site.github.is_project_page %}
         <p class="copyright">Workshop maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
         {% endif %}


### PR DESCRIPTION
This now accommodates the fact that code snippets, example programs taken from course episodes on Software Carpentry covered by the MIT licence. Closes #25. 